### PR TITLE
Make compatible with MediaWiki 1.31

### DIFF
--- a/includes/OnyxTemplate.php
+++ b/includes/OnyxTemplate.php
@@ -874,7 +874,7 @@ class OnyxTemplate extends BaseTemplate {
 
 		// Have the MediaWiki parser output the Template:Onyx/Sidebar/Static page
 		// and insert it into the page
-		$html .= $wgOut->parseAsContent( '{{Onyx/Sidebar/Static}}' );
+		$html .= $wgOut->parse( '{{Onyx/Sidebar/Static}}' );
 
 		// Close container div for module
 		$html .= Html::closeElement( 'div' );
@@ -1100,7 +1100,7 @@ class OnyxTemplate extends BaseTemplate {
 
 		// Have the MediaWiki parser output the Template:Onyx/Sidebar/Sticky page
 		// and insert it into the page
-		$html .= $wgOut->parseAsContent( '{{Onyx/Sidebar/Sticky}}' );
+		$html .= $wgOut->parse( '{{Onyx/Sidebar/Sticky}}' );
 
 		// Close container div for module
 		$html .= Html::closeElement( 'div' );


### PR DESCRIPTION
I update the site between LTS versions for stability. parseAsContent was added in 1.32. Our next update will be 1.31 -> 1.35