### PR TITLE
Add support for MediaWiki 1.35

### DIFF
--- a/includes/Config.php
+++ b/includes/Config.php
@@ -17,7 +17,7 @@ class Config {
 		'show-sidebar-by-default' => true,
 		'show-sidebar-by-default-on-edit' => false,
 		'show-sidebar-by-default-on-main-page' => false,
-		'enable-recent-changes-module' => true,
+		'enable-recent-changes-module' => false,
 		'recent-changes-cache-expiry-time' => 30,
 		'recent-changes-amount' => 7,
 		'enable-page-contents-module' => true,

--- a/includes/OnyxTemplate.php
+++ b/includes/OnyxTemplate.php
@@ -1514,7 +1514,7 @@ class OnyxTemplate extends BaseTemplate {
 		$html .= Html::openElement( 'ul', [ 'id' => 'onyx-tools-list' ] );
 
 		// Make a list item for each of the tool links
-		foreach ( $this->getToolbox() as $key => $toolboxItem ) {
+		foreach ( $this->data['sidebar']['TOOLBOX'] ?? [] as $key => $toolboxItem ) {
 			$html .= $this->makeListItem( $key, $toolboxItem );
 		}
 

--- a/includes/SkinOnyx.php
+++ b/includes/SkinOnyx.php
@@ -19,15 +19,6 @@ class SkinOnyx extends SkinTemplate {
 	public function initPage( OutputPage $out ) : void {
 		parent::initPage( $out );
 		$out->addModules( 'skins.onyx.js' );
-	}
-
-	/**
-	 * Add CSS to the skin, via ResourceLoader.
-	 *
-	 * @param OutputPage $out
-	 */
-	function setupSkinUserCss( OutputPage $out ) : void {
-		parent::setupSkinUserCss( $out );
 		$out->addModuleStyles( [
 			'mediawiki.skinning.interface',
 			'skins.onyx.styles'

--- a/skin.json
+++ b/skin.json
@@ -30,6 +30,7 @@
 
 	"ResourceModules": {
 		"skins.onyx.styles": {
+			"class": "ResourceLoaderSkinModule",
 			"styles": {
 				"resources/onyx-screen.css": {
 					"media": "screen"


### PR DESCRIPTION
* Default $wgOnyxEnableRecentChangesModule to false as
$wgOnyxEnableRecentChangesModule = true; doesn't seem to work in
1.35 (Call to a member function makeKey() on null)
* setupSkinUserCss is deprecated in 1.35
* getToolbox is deprecated in 1.35

I've marked this skin as unstable on https://www.mediawiki.org/wiki/Skin:Onyx. This change can be reverted once this skin is stable on 1.35 👍 